### PR TITLE
applications: nrf_desktop: Fix DTS conflicts on nRF54L (pwm_led0 label)

### DIFF
--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_0.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_2_0.overlay
@@ -10,6 +10,11 @@
 };
 
 / {
+	/* Disable pwmleds and redefine them to align configuration with CAF LEDs requirements.
+	 * The configuration needs to match the used board revision (v0.2.0).
+	 */
+	/delete-node/ pwmleds;
+
 	pwmleds0 {
 		compatible = "pwm-leds";
 		status = "okay";

--- a/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/applications/nrf_desktop/configuration/nrf54l15pdk_nrf54l15_cpuapp/boards/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -12,6 +12,11 @@
 };
 
 / {
+	/* Disable pwmleds and redefine them to align configuration with CAF LEDs requirements.
+	 * The configuration needs to match the used board revision (v0.3.0).
+	 */
+	/delete-node/ pwmleds;
+
 	pwmleds0 {
 		compatible = "pwm-leds";
 		status = "okay";


### PR DESCRIPTION
Change removes pwmleds node defined by the nrf54l15pdk_nrf54l15_cpuapp board to prevent DTS conflicts. Application defines PWM LEDs on its own.

Jira: NCSDK-26516