### PR TITLE
scripts: requirements-build: update nrf-regtool to 5.4.0

### DIFF
--- a/scripts/requirements-build.txt
+++ b/scripts/requirements-build.txt
@@ -6,4 +6,4 @@ imagesize>=1.2.0
 intelhex
 pylint
 zcbor~=0.8.0
-nrf-regtool~=5.3.2
+nrf-regtool~=5.4.0


### PR DESCRIPTION
Update nrf-regtool to 5.4.0 which reserves GPIO pins corresponding to used ADC channels.

