### PR TITLE
tests: multicore: idle: Add s2ram configuration

### DIFF
--- a/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
+++ b/tests/benchmarks/multicore/idle/boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+       power-states {
+               idle: idle {
+                       compatible = "zephyr,power-state";
+                       power-state-name = "suspend-to-idle";
+                       min-residency-us = <100000>;
+               };
+
+               s2ram: s2ram {
+                       compatible = "zephyr,power-state";
+                       power-state-name = "suspend-to-ram";
+                       min-residency-us = <800000>;
+               };
+       };
+};
+
+&cpu {
+       cpu-power-states = <&idle &s2ram>;
+};

--- a/tests/benchmarks/multicore/idle/testcase.yaml
+++ b/tests/benchmarks/multicore/idle/testcase.yaml
@@ -54,3 +54,17 @@ tests:
       - nrf54h20dk/nrf54h20/cpuapp
     extra_args:
       SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+
+  benchmarks.multicore.idle.nrf54h20dk_cpuapp_cpurad.s2ram:
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_args:
+      SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+      CONFIG_PM=y CONFIG_PM_S2RAM=y CONFIG_POWEROFF=y CONFIG_PM_S2RAM_CUSTOM_MARKING=y
+      CONFIG_CONSOLE=n CONFIG_UART_CONSOLE=n CONFIG_SERIAL=n CONFIG_GPIO=n CONFIG_BOOT_BANNER=n
+      remote_CONFIG_PM=y remote_CONFIG_POWEROFF=y remote_CONFIG_CONSOLE=n
+      remote_CONFIG_UART_CONSOLE=n remote_CONFIG_SERIAL=n remote_CONFIG_GPIO=n
+      remote_CONFIG_BOOT_BANNER=n
+      DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_s2ram.overlay"


### PR DESCRIPTION
Add configuration that allows to put nRF54H20 into Suspend To RAM state (app and rad core).